### PR TITLE
Fixes bug in texinfo for Debian builds

### DIFF
--- a/toolchain/gcc/patches/4.7-linaro/010-documentation.patch
+++ b/toolchain/gcc/patches/4.7-linaro/010-documentation.patch
@@ -1,0 +1,23 @@
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -4251,18 +4251,10 @@
+ doc/gccint.info: $(TEXI_GCCINT_FILES)
+ doc/cppinternals.info: $(TEXI_CPPINT_FILES)
+ 
+-doc/%.info: %.texi
+-	if [ x$(BUILD_INFO) = xinfo ]; then \
+-		$(MAKEINFO) $(MAKEINFOFLAGS) -I . -I $(gcc_docdir) \
+-			-I $(gcc_docdir)/include -o $@ $<; \
+-	fi
++doc/%.info:
+ 
+ # Duplicate entry to handle renaming of gccinstall.info
+-doc/gccinstall.info: $(TEXI_GCCINSTALL_FILES)
+-	if [ x$(BUILD_INFO) = xinfo ]; then \
+-		$(MAKEINFO) $(MAKEINFOFLAGS) -I $(gcc_docdir) \
+-			-I $(gcc_docdir)/include -o $@ $<; \
+-	fi
++doc/gccinstall.info:
+ 
+ doc/cpp.dvi: $(TEXI_CPP_FILES)
+ doc/gcc.dvi: $(TEXI_GCC_FILES)


### PR DESCRIPTION
As per issue reported here: https://github.com/8devices/carambola2/issues/19, please apply to correct builds on Debian-like systems.
