### PR TITLE
ca-certificates: update to version 20161102

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
-PKG_VERSION:=20160104
+PKG_VERSION:=20161102
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/c/ca-certificates
-PKG_MD5SUM:=d9665a83d0d3ef8176a38e6aa20458e9
+PKG_MD5SUM:=74642bd9b9e0a449fa55e6632070745f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
 PKG_INSTALL:=1


### PR DESCRIPTION
As title says, build broke because the old link is probably down.